### PR TITLE
Add Github action for testing with different PHP versions

### DIFF
--- a/.github/workflows/test-in-all-php.yml
+++ b/.github/workflows/test-in-all-php.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  phpunit:
+  run_tests:
     name: PHPUnit
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-in-all-php.yml
+++ b/.github/workflows/test-in-all-php.yml
@@ -1,8 +1,12 @@
 name: Test In All PHP Versions
 
 on:
-  pull_request:
-    branches: [main]
+  push:
+    branches:
+      - "*" # matches every branch that doesn't contain a '/'
+      - "*/*" # matches every branch containing a single '/'
+      - "**" # matches every branch
+      - "!main" # excludes master
 
 jobs:
   run_tests:

--- a/.github/workflows/test-in-all-php.yml
+++ b/.github/workflows/test-in-all-php.yml
@@ -13,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
+          #- "7.4"
+          #- "8.0"
           - "8.1"
           - "8.2"
         dependency-versions:

--- a/.github/workflows/test-in-all-php.yml
+++ b/.github/workflows/test-in-all-php.yml
@@ -2,7 +2,7 @@ name: Test In All PHP Versions
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   phpunit:

--- a/.github/workflows/test-in-all-php.yml
+++ b/.github/workflows/test-in-all-php.yml
@@ -1,0 +1,40 @@
+name: Test In All PHP Versions
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  phpunit:
+    name: PHPUnit
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - "7.4"
+          - "8.0"
+          - "8.1"
+          - "8.2"
+        dependency-versions:
+          - "lowest"
+          - "highest"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: ${{ matrix.dependency-versions }}
+
+      - name: Run PHPUnit
+        run: composer test

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "illuminate/collections": "^10.17"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "^10.0"
     },
     "version": "1.0.0",
     "license": "MIT",


### PR DESCRIPTION
The action will run following commands for PHP 8.1 and PHP 8.2 correspondingly with highest and lowest dependency options;

- `composer install`
- `composer tests`

PS: I need to add a lower limit for PHPUnit.

