### PR TITLE
laravel 8,9,10 support added

### DIFF
--- a/.github/workflows/test-in-all-php.yml
+++ b/.github/workflows/test-in-all-php.yml
@@ -1,12 +1,6 @@
 name: Test In All PHP Versions
 
-on:
-  push:
-    branches:
-      - "*" # matches every branch that doesn't contain a '/'
-      - "*/*" # matches every branch containing a single '/'
-      - "**" # matches every branch
-      - "!main" # excludes master
+on: [push, pull_request]
 
 jobs:
   run_tests:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 .idea/
 .DS_Store
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "type": "library",
     "require": {
         "php":">=8.1",
-        "illuminate/collections": "^10.17"
+        "illuminate/collections": "^8.65 || ^9.0 || ^10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0"


### PR DESCRIPTION
The package requires the PHP 8.1 feature of enums. Currently, it mandates Laravel 10 as a dependency. However, it's worth noting that the package is also compatible with Laravel versions from 8.65 onward, as these versions support PHP 8.1. [related post](https://blog.laravel.com/our-ecosystem-is-php81-ready)

When running PHPUnit Test, the .phpunit.result.cache file is generated. This file has also been added to the .gitignore file.