### PR TITLE
Adds two new methods in `EnumConcern`: `fromValue` and `valueNamePairs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ enum TestEnum: string
 | `exceptAsArray`       | Get a subset of the values as an array, excluding the specified cases (keys / names).         | `cases`, `method = ''` (optional)                           | `array`     |
 | `first`               | Get the first value in the Enum.                                                              | `method = ''` (optional)                                   | `mixed`     |
 | `last`                | Get the last value in the Enum.                                                               | `method = ''` (optional)                                   | `mixed`     |
+| `fromValue`           | Create an Enum object from a string value.                                                    | `value`                                                    | `object`     |
+| `valueNamePairs`      | Get the key-value pairs of value and transformed value (if a method is specified).            | `method = ''` (optional)                                   | `Collection` |
 
 <hr/>
 
@@ -1058,6 +1060,32 @@ Fruits::last('names');
 // Result: "Apple"
 ```
 <hr />
+
+### fromValue() Method
+Create an Enum object from a string value.
+```php
+$greenEnum = Color::fromValue("Green");
+// Result:
+// App\Enums\Color {
+//   +name: "GREEN"
+//   +value: "Green"
+// }
+```
+If the value "Green" exists in the `Color` Enum, this method will return the corresponding Enum object. If not, it will throw an `InvalidArgumentException`.
+
+### valueNamePairs() Method
+Get the key-value pairs of value and transformed value (if a method is specified).
+
+```php
+$pairs = Color::valueNamePairs('translateToTurkish');
+// Result:
+// Illuminate\Support\Collection {
+//    "Red" => "Kırmızı",
+//    "Green" => "Yeşil",
+//    "Blue" => "Mavi"
+// }
+```
+<ht />
 
 ## Tests
 ```bash

--- a/src/EnumConcern.php
+++ b/src/EnumConcern.php
@@ -252,4 +252,37 @@ trait EnumConcern
     {
         return self::all($method)->last();
     }
+
+    /**
+     * Create an Enum object from a string value.
+     *
+     * @param string $value The value to match with the existing elements of the Enum.
+     * @return object Returns an Enum object if the value matches an existing element.
+     * @throws InvalidArgumentException if the value does not match any existing elements.
+     */
+    public static function fromValue(string $value) : object
+    {
+        if (self::has($value)) {
+            return self::from($value);
+        }
+
+        throw new \InvalidArgumentException("The value '{$value}' does not match any existing elements in the Enum.");
+    }
+
+    /**
+     * Get the key-value pairs of value and transformed value (if a method is specified).
+     *
+     * @param string $method (optional) If provided, the specified method will be called on each value.
+     * @return Collection Returns a Collection containing the key-value pairs.
+     */
+    public static function valueNamePairs(string $method = '') : Collection
+    {
+        if (!method_exists(self::class, $method)) {
+            return collect(self::cases())->pluck('value', 'value');
+        }
+
+        return collect(self::cases())->mapWithKeys(function ($item) use ($method) {
+            return [$item->value => self::from($item->value)->$method()];
+        });
+    }
 }

--- a/tests/EnumConcernTest.php
+++ b/tests/EnumConcernTest.php
@@ -602,7 +602,59 @@ class EnumConcernTest extends TestCase {
         $this->assertEquals(Fruits::last('emojis'),'🍎');
     }
 
+    public function testFromValueValid(): void
+    {
+        $this->assertEquals(Fruits::fromValue(1)->value, 1); 
+    }
 
+    public function testFromValueInvalid(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("The value '100' does not match any existing elements in the Enum.");
+        Fruits::fromValue(100);
+    }
+
+    public function testValueNamePairsWithoutMethod(): void
+    {
+        $expected = collect([
+            1 => 1,
+            2 => 2,
+            3 => 3,
+            4 => 4,
+            5 => 5,
+            6 => 6,
+            7 => 7,
+        ]);
+        $this->assertEquals(Fruits::valueNamePairs(), $expected);
+    }
+
+    public function testValueNamePairsWithMethod(): void
+    {
+        $expected = collect([
+            1 => "🍌",
+            2 => "🍓",
+            3 => "🍒",
+            4 => "🍉",
+            5 => "🍊",
+            6 => "🥝",
+            7 => "🍎",
+        ]);
+        $this->assertEquals(Fruits::valueNamePairs('emojis'), $expected);
+    }
+
+    public function testValueNamePairsWithInvalidMethod(): void
+    {
+        $expected = collect([
+            1 => 1,
+            2 => 2,
+            3 => 3,
+            4 => 4,
+            5 => 5,
+            6 => 6,
+            7 => 7,
+        ]);
+        $this->assertEquals(Fruits::valueNamePairs('invalidMethod'), $expected);
+    }
 }
 
 enum Fruits: int


### PR DESCRIPTION
Thank you very much for creating this package which I like very much. I have been playing around with it for a few days on a personal project and I find it super useful. Here is my modest contribution of two methods that I think could be useful. Any feedback is appreciated :)

## Description

This PR adds two new methods to the Enum class - `fromValue` and `valueNamePairs`.

- `fromValue(string $value)`: Returns an Enum object from a string value.

- `valueNamePairs(string $method = '')`: Returns key-value pairs of enum values and their transformed names. This adds more flexibility compared to the existing `all()` method by allowing transformed values. Useful for quick use in forms (i.e. within a select).