### PR TITLE
Enhance fromValue to Support Custom Method-Based Matching

### DIFF
--- a/src/EnumConcern.php
+++ b/src/EnumConcern.php
@@ -257,14 +257,19 @@ trait EnumConcern
     /**
      * Create an Enum object from a string value.
      *
-     * @param string $value The value to match with the existing elements of the Enum.
-     * @return object Returns an Enum object if the value matches an existing element.
+     * @param string|int $value The value to match with the existing elements of the Enum.
+     * @param string $method (optional) If provided, the specified method will be called on each value.
+     * @return self Returns an Enum object if the value matches an existing element.
      * @throws InvalidArgumentException if the value does not match any existing elements.
      */
-    public static function fromValue(string $value) : object
+    public static function fromValue(string|int $value, string $method = '') : self
     {
-        if (self::has($value)) {
-            return self::from($value);
+        if (self::has($value, $method)) {
+            return collect(self::cases())->first(function (self $case) use ($value, $method) {
+                return $method
+                    ? $value === $case->$method()
+                    : $value === $case->value;
+            });
         }
 
         throw new \InvalidArgumentException("The value '{$value}' does not match any existing elements in the Enum.");

--- a/tests/EnumConcernTest.php
+++ b/tests/EnumConcernTest.php
@@ -614,6 +614,18 @@ class EnumConcernTest extends TestCase {
         Fruits::fromValue(100);
     }
 
+    public function testFromValueValidWithCustomMethod()
+    {
+        $this->assertEquals(Fruits::fromValue('🍎', 'emojis')->value, 7);
+    }
+
+    public function testFromValueInvalidWithCustomMethod()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("The value '🦋' does not match any existing elements in the Enum.");
+        Fruits::fromValue('🦋', 'emojis');
+    }
+
     public function testValueNamePairsWithoutMethod(): void
     {
         $expected = collect([


### PR DESCRIPTION
This PR extends the fromValue method in the EnumConcern trait to support matching enum cases using the result of a custom method, in addition to the default value property.

**What Changed:**
Added an optional $method parameter to fromValue.

When a method name is passed, each enum case will be checked by calling that method and comparing its return value against the provided $value.

If no method is provided, the method behaves as it always has — matching based on the case’s native value.

**Why:**
This enhancement allows developers to retrieve enum instances based on alternative representations such as:

Emojis

Labels

Translations

Custom identifiers

It improves the trait’s flexibility, especially in use cases involving UI display values or external input formats that differ from internal enum values.

**Example Usage:**
`Fruits::fromValue('🍎', 'emojis'); // returns Fruits::APPLE, assuming emojis() returns '🍎'`

**Tests:**
✅ Added test case for fromValue using a custom method.